### PR TITLE
Add highlighting for SQL keywords

### DIFF
--- a/VS2012-Dark.xml
+++ b/VS2012-Dark.xml
@@ -139,7 +139,7 @@ Note:        I don't claim any ownership of this theme. It is merely a replica o
             <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="608B4E" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="9B9B9B" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="4E9CD6" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="B5CEA8" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="6" fgColor="D69D85" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING2" styleID="7" fgColor="D69D85" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" />


### PR DESCRIPTION
I noticed the keywords for SQL were not being highlighted so I edited the theme to do so.

![image](https://cloud.githubusercontent.com/assets/4080902/11607778/df988974-9b2a-11e5-9add-1d385644b367.png)
