### PR TITLE
change active fold color to grey

### DIFF
--- a/VS2012-Dark.xml
+++ b/VS2012-Dark.xml
@@ -724,6 +724,7 @@ Note:        I don't claim any ownership of this theme. It is merely a replica o
         <WidgetStyle name="Line number margin" styleID="33" fgColor="2B91AF" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold" styleID="0" fgColor="2E3436" bgColor="EEEEEC" fontStyle="0" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="1E1E1E" bgColor="1E1E1E" fontStyle="0" />
+        <WidgetStyle name="Fold active" styleID="0" fgColor="AAAAAA" />
         <WidgetStyle name="White space symbol" styleID="0" fgColor="808080" bgColor="1E1E1E" fontStyle="0" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="3687E0" fgColor="DCDCDC" fontStyle="0" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="B55B0B" fgColor="DCDCDC" fontName="" fontSize="" fontStyle="0" />


### PR DESCRIPTION
By default, the Npp-VS2012-Dark theme doesn't change the color of the fold icons, which kinda distracts as it's red instead of grey. This PR fixes this by changing the color to a light grey, similar to the grey used in Visual Studio